### PR TITLE
modify requirements.txt to install in mac

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ einops==0.3.0
 transformers>4.19.2
 open-clip-torch==2.7.0
 lightning
-triton>=2.0.0.dev20221005
+triton>=2.0.0.dev20221005; platform_system == "Linux"
 deepspeed>=0.7.5


### PR DESCRIPTION
I added `triton>=2.0.0.dev20221005; platform_system == "Linux"` to the requirements to install locally in mac