### PR TITLE
Skip DeepSpeed Optimization if not available or not supported

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #.idea/
 outputs/
 profiles/
+v1-5-pruned-emaonly.ckpt

--- a/ldm/deepspeed_replace.py
+++ b/ldm/deepspeed_replace.py
@@ -6,17 +6,26 @@ import torch
 from functools import partial
 from dataclasses import dataclass
 import time
-import deepspeed.ops.transformer as transformer_inference
-from deepspeed.ops.transformer.inference.diffusers_attention import DeepSpeedDiffusersAttention
-from deepspeed.ops.transformer.inference.diffusers_transformer_block import DeepSpeedDiffusersTransformerBlock
-from deepspeed.ops.transformer.inference.diffusers_2d_transformer import Diffusers2DTransformerConfig
+from lightning_utilities.core.imports import package_available
+
 from ldm.modules.attention import CrossAttention, BasicTransformerBlock
-from deepspeed.module_inject.replace_policy import UNetPolicy, DSPolicy
 from ldm.models.diffusion.ddpm import DiffusionWrapper
 from ldm.models.autoencoder import AutoencoderKL
 from ldm.modules.encoders.modules import FrozenCLIPEmbedder
-from deepspeed.inference.engine import InferenceEngine
 
+if package_available("deepspeed"):
+    import deepspeed.ops.transformer as transformer_inference
+    from deepspeed.ops.transformer.inference.diffusers_attention import DeepSpeedDiffusersAttention
+    from deepspeed.ops.transformer.inference.diffusers_transformer_block import DeepSpeedDiffusersTransformerBlock
+    from deepspeed.ops.transformer.inference.diffusers_2d_transformer import Diffusers2DTransformerConfig
+    from deepspeed.inference.engine import InferenceEngine
+    from deepspeed.module_inject.replace_policy import UNetPolicy, DSPolicy
+else:
+    class InferenceEngine:
+        pass
+
+    class DSPolicy:
+        pass
 
 class InferenceEngine(InferenceEngine):
 

--- a/ldm/detect_target.py
+++ b/ldm/detect_target.py
@@ -1,0 +1,23 @@
+import os
+from subprocess import PIPE, Popen
+
+# Credits to AITemplate Team
+# https://github.com/facebookincubator/AITemplate/blob/main/python/aitemplate/testing/detect_target.py
+def _detect_cuda():
+    try:
+        proc = Popen(
+            ["nvidia-smi", "--query-gpu=gpu_name", "--format=csv"],
+            stdout=PIPE,
+            stderr=PIPE,
+        )
+        stdout, _ = proc.communicate()
+        stdout = stdout.decode("utf-8")
+        if "A100" in stdout or "RTX 30" in stdout or "A30" in stdout:
+            return "80"
+        if "V100" in stdout:
+            return "70"
+        if "T4" in stdout:
+            return "75"
+        return None
+    except Exception:
+        return None

--- a/ldm/lightning.py
+++ b/ldm/lightning.py
@@ -61,8 +61,8 @@ class LightningStableDiffusion(L.LightningModule):
     ):
         super().__init__()
 
-        if device == "mps" and fp16:
-            logger.warn("You provided fp16=True but it isn't supported on `mps`. Skipping...")
+        if device in ("mps", "cpu") and fp16:
+            logger.warn(f"You provided fp16=True but it isn't supported on `{device}`. Skipping...")
             fp16 = False
 
         config = OmegaConf.load(f"{config_path}")

--- a/ldm/lightning.py
+++ b/ldm/lightning.py
@@ -52,7 +52,7 @@ class LightningStableDiffusion(L.LightningModule):
         self,
         config_path: str,
         checkpoint_path: str,
-        device: torch.device,
+        device: str,
         size: int = 512,
         fp16: bool = True,
         sampler: str = "ddim",
@@ -77,8 +77,8 @@ class LightningStableDiffusion(L.LightningModule):
         if use_deepspeed:
             if not package_available("deepspeed"):
                 logger.warn("You provided use_deepspeed=True but Deepspeed isn't installed. Skipping...")
-            elif torch.cuda.is_available() and _detect_cuda() not in ["80"]:
-                logger.warn("You provided use_deepspeed=True but Deepspeed isn't supported on your architecture. Skipping...")
+            elif _detect_cuda() not in ["80"]:
+                logger.warn("You provided `use_deepspeed=True` but Deepspeed isn't supported on your architecture. Skipping...")
             else:
                 deepspeed_injection(self.model, fp16=fp16, enable_cuda_graph=enable_cuda_graph)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ einops==0.3.0
 transformers>4.19.2
 open-clip-torch==2.7.0
 lightning
-triton>=2.0.0.dev20221005
-deepspeed>=0.7.5
+triton>=2.0.0.dev20221005; platform_system == "Linux"
+deepspeed>=0.7.5; platform_system == "Linux"

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -157,7 +157,7 @@ def main(opt):
         device="cuda",
         fp16=True,
         use_deepspeed=True,
-        enable_cuda_graph=True,
+        enable_cuda_graph=True, # Currently enabled only for batch size 1.
         use_inference_context=False,
         steps=30,
     )

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -155,7 +155,10 @@ def main(opt):
         config_path=opt.config,
         checkpoint_path=opt.ckpt,
         device="cuda",
-        sampler=opt.sampler,
+        fp16=True,
+        use_deepspeed=True,
+        enable_cuda_graph=True,
+        use_inference_context=False,
         steps=30,
     )
 

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -163,7 +163,10 @@ def main(opt):
     )
 
     for batch_size in [1, 2, 4]:
-        t, max_memory, images = benchmark_fn(10, 5, model.predict_step, prompts=[opt.prompt] * batch_size, batch_idx=0)
+        if batch_size == 1:
+            t, max_memory, images = benchmark_fn(10, 5, model.predict_step, prompts=opt.prompt, batch_idx=0)
+        else:
+            t, max_memory, images = benchmark_fn(10, 5, model.predict_step, prompts=[opt.prompt] * batch_size, batch_idx=0)
         print(f"Average time {t} secs on batch size {batch_size}.")
         print(f"Max GPU Memory cost is {max_memory} MB.")
 

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -156,7 +156,7 @@ def main(opt):
         checkpoint_path=opt.ckpt,
         device="cuda",
         fp16=True,
-        use_deepspeed=True,
+        use_deepspeed=True, # Supported on Ampere and RTX, skipped otherwise.
         enable_cuda_graph=True, # Currently enabled only for batch size 1.
         use_inference_context=False,
         steps=30,

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -161,7 +161,7 @@ def main(opt):
     os.makedirs(opt.outdir, exist_ok=True)
     seed_everything(opt.seed)
 
-    device = "cpu"
+    device = "cuda" if torch.cuda.is_available() else "mps"
 
     model = LightningStableDiffusion(
         config_path=opt.config,

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import time
+import torch
 from pytorch_lightning import seed_everything
 from ldm.lightning import LightningStableDiffusion
 
@@ -160,13 +161,13 @@ def main(opt):
     os.makedirs(opt.outdir, exist_ok=True)
     seed_everything(opt.seed)
 
-    device = "mps"
+    device = "cuda" if torch.cuda.is_available() else "mps"
 
     model = LightningStableDiffusion(
         config_path=opt.config,
         checkpoint_path=opt.ckpt,
         device=device,
-        fp16=True,
+        fp16=True, # Supported on GPU and CPU only, skipped otherwise.
         use_deepspeed=True, # Supported on Ampere and RTX, skipped otherwise.
         enable_cuda_graph=True, # Currently enabled only for batch size 1.
         use_inference_context=False,

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -161,7 +161,7 @@ def main(opt):
     os.makedirs(opt.outdir, exist_ok=True)
     seed_everything(opt.seed)
 
-    device = "cuda" if torch.cuda.is_available() else "mps"
+    device = "cpu"
 
     model = LightningStableDiffusion(
         config_path=opt.config,


### PR DESCRIPTION
The PR https://github.com/Lightning-AI/stablediffusion/pull/2 broke inference on MacOs as triton isn't supported.

This PR does the following:
* turns optimisation off by default
* make DeepSpeed optional
* make DeepSpeed and Triton installable only on 
* skip DeepSpeed optimisation if not available or supported. 

TODOs:
- [x] Validate it works with model.predict_step(prompts="text....")
- [x] Validate inference it works on MacOS
- [x] Validate inference it works on CPU