### PR TITLE
Add Flash Attention Layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+from ghcr.io/gridai/base-images:v1.19-gpu-launcher-0.0.43-lightning-1.8.6
+
+COPY requirements.txt requirements.txt
+
+RUN pip install -r requirements.txt

--- a/ldm/deepspeed_replace.py
+++ b/ldm/deepspeed_replace.py
@@ -7,13 +7,16 @@ from functools import partial
 from dataclasses import dataclass
 import time
 from lightning_utilities.core.imports import package_available
-
+from torch import nn
 from ldm.modules.attention import CrossAttention, BasicTransformerBlock
 from ldm.models.diffusion.ddpm import DiffusionWrapper
 from ldm.models.autoencoder import AutoencoderKL
 from ldm.modules.encoders.modules import FrozenCLIPEmbedder
 from ldm.detect_target import _detect_cuda
 import logging
+import math
+from torch import nn, einsum
+from einops import rearrange, repeat
 
 if package_available("deepspeed"):
     import deepspeed.ops.transformer as transformer_inference
@@ -30,6 +33,7 @@ else:
         pass
 
 logger = logging.getLogger(__name__)
+inference_cuda_module = None
 
 class InferenceEngine(InferenceEngine):
 
@@ -224,12 +228,12 @@ class UNetPolicy(DSPolicy):
             return ReplayCudaGraphUnet(module, enable_cuda_graph=enable_cuda_graph)
         return module
 
-    def attention(self, client_module):
+    def attention(self, client_module, use_triton_attention: bool = True):
         qw = client_module.to_q.weight
         kw = client_module.to_k.weight
         vw = client_module.to_v.weight
 
-        if qw.shape[1] == kw.shape[1]:
+        if use_triton_attention and qw.shape[1] == kw.shape[1]:
             qkvw = torch.nn.Parameter(torch.cat((qw, kw, vw), dim=0), requires_grad=False)
 
             return qkvw, \
@@ -271,6 +275,7 @@ class ClipEncoderPolicy(DSPolicy):
 GENERIC_POLICIES = [UNetPolicy, VAEPolicy, ClipEncoderPolicy]
 
 
+
 def _module_match(module):
     for policy in GENERIC_POLICIES:
         policy = policy()
@@ -278,30 +283,164 @@ def _module_match(module):
             return policy
     return None
 
+
+class FlashAttention(nn.Module):
+
+    def __init__(self, hidden_size: int, hidden_size_out: int, heads: int, fp16: bool = True, device: str = "cuda", max_out_tokens: int = 4096):
+        super().__init__()
+
+        self.hidden_size = hidden_size
+        self.max_out_tokens = max_out_tokens
+        self.heads = heads
+
+        dtype = torch.float16 if fp16 else torch.float32
+
+        self.attn_kw = nn.Parameter(
+            torch.empty(
+                hidden_size,
+                hidden_size,
+                dtype=dtype,
+                device=device
+            ), requires_grad=False
+        )
+
+        self.attn_vw = nn.Parameter(
+            torch.empty(
+                hidden_size,
+                hidden_size,
+                dtype=dtype,
+                device=device
+            ), requires_grad=False)
+
+        self.attn_qw = nn.Parameter(
+            torch.empty(
+                hidden_size,
+                hidden_size_out,
+                dtype=dtype,
+                device=device
+            ), requires_grad=False
+        )
+
+        self.attn_ow = nn.Parameter(torch.empty(hidden_size,
+                                                hidden_size,
+                                                dtype=dtype,
+                                                device=device),
+                                    requires_grad=False)
+
+        self.attn_ob = nn.Parameter(torch.empty(hidden_size,
+                                                dtype=dtype,
+                                                device=device),
+                                    requires_grad=False)
+        self.do_out_bias = True
+
+        global inference_cuda_module
+        if inference_cuda_module is None:
+            from deepspeed.ops import op_builder
+            builder = op_builder.InferenceBuilder()
+            inference_cuda_module = builder.load()
+
+        self.linear_func = inference_cuda_module.linear_layer_fp16
+
+        self.norm_factor = math.sqrt(math.sqrt(hidden_size // heads))
+
+        self.scale = (1 / self.norm_factor) * (1 / self.norm_factor) 
+
+    def forward(self, input, context=None, input_mask=None):
+        from flash_attn.flash_attn_interface import _flash_attn_forward
+
+        batch_size = input.shape[0]
+        seqlen = input.shape[1]
+        cu_seqlens = torch.arange(0, (batch_size + 1) * seqlen, step=seqlen, dtype=torch.int32, device=self.attn_kw.device)
+        do_flash_attn = (input.shape[-1] / self.heads <= 128) and context is None
+
+        if not do_flash_attn:
+            query = torch.matmul(input, self.attn_qw)
+            if context is None:
+                key = torch.matmul(input, self.attn_kw)
+                value = torch.matmul(input, self.attn_vw)
+            else:
+                key = torch.matmul(context, self.attn_kw)
+                value = torch.matmul(context, self.attn_vw)
+
+            query = rearrange(query, 'b n (h d) -> (b h) n d', h=self.heads)
+            key = rearrange(key, 'b n (h d) -> (b h) n d', h=self.heads)
+            value = rearrange(value, 'b n (h d) -> (b h) n d', h=self.heads)
+        else:
+            query = torch.matmul(input, self.attn_qw)
+            key = torch.matmul(input, self.attn_kw)
+            value = torch.matmul(input, self.attn_vw)
+
+            query = query.reshape((batch_size * seqlen, self.heads, -1)).contiguous()
+            key = key.reshape((batch_size * seqlen, self.heads, -1)).contiguous()
+            value = value.reshape((batch_size * seqlen, self.heads, -1)).contiguous()
+
+        if do_flash_attn:
+            context_layer, _, _ = _flash_attn_forward(query, key, value, torch.empty_like(query), cu_seqlens, cu_seqlens, seqlen, seqlen, 0.0, self.scale, causal=None, return_softmax=False)
+            context_layer = context_layer.reshape((batch_size, seqlen, -1))
+        else:
+            sim = einsum('b i d, b j d -> b i j', query, key) * self.scale
+            del query, key
+
+            sim = sim.softmax(dim=-1)
+
+            out = einsum('b i j, b j d -> b i d', sim, value)
+            context_layer = rearrange(out, '(b h) n d -> b n (h d)', h=self.heads)
+
+        return torch.matmul(context_layer, self.attn_ow)
+
+
+class DeepSpeedFlashDiffusersTransformerBlock(DeepSpeedDiffusersTransformerBlock):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if isinstance(self.attn_1, FlashAttention):
+            self.attn_1.do_out_bias = False
+            self.attn_1_bias = self.attn_1.attn_ob
+
+        if isinstance(self.attn_2, FlashAttention):
+            self.attn_2.do_out_bias = False
+            self.attn_2_bias = self.attn_2.attn_ob
+
+
 # Inspired from https://github.com/microsoft/DeepSpeed/blob/master/deepspeed/module_inject/replace_module.py#L201
-def deepspeed_injection(module, fp16=True, enable_cuda_graph=True):
+def deepspeed_injection(
+    module,
+    fp16=True,
+    enable_cuda_graph=True,
+    use_triton_attention=False
+):
 
     if not torch.cuda.is_available():
         logger.warn("You provided use_deepspeed=True but Deepspeed isn't supported on your architecture. Skipping...")
         return
 
     def replace_attn(child, policy):
-        policy_attn = policy.attention(child)
+        policy_attn = policy.attention(child, use_triton_attention=use_triton_attention)
         if policy_attn is None:
             return child
+
         if len(policy_attn) == 5:
             qkvw, attn_ow, attn_ob, hidden_size, heads = policy_attn
         else:
             qw, kw, vw, attn_ow, attn_ob, hidden_size, heads = policy_attn
 
-        config = transformer_inference.DeepSpeedInferenceConfig(
-            hidden_size=hidden_size,
-            heads=heads,
-            fp16=fp16,
-            triangular_masking=False,
-            max_out_tokens=4096,
-        )
-        attn_module = DeepSpeedDiffusersAttention(config)
+        if use_triton_attention:
+            config = transformer_inference.DeepSpeedInferenceConfig(
+                hidden_size=hidden_size,
+                heads=heads,
+                fp16=fp16,
+                triangular_masking=False,
+                max_out_tokens=4096,
+            )
+            attn_module = DeepSpeedDiffusersAttention(config)
+        else:
+            attn_module = FlashAttention(
+                hidden_size=hidden_size,
+                heads=heads,
+                fp16=fp16,
+                hidden_size_out=vw.shape[-1],
+                max_out_tokens=4096,
+            )                
 
         def transpose(data):
             data = data.contiguous()
@@ -326,7 +465,7 @@ def deepspeed_injection(module, fp16=True, enable_cuda_graph=True):
     def replace_attn_block(child, policy):
         # Track DeepSpeed Issue: https://github.com/microsoft/DeepSpeed/issues/2681
         config = Diffusers2DTransformerConfig(int8_quantization=False)
-        return DeepSpeedDiffusersTransformerBlock(child, config)
+        return DeepSpeedFlashDiffusersTransformerBlock(child, config)
 
     new_policies = {
         CrossAttention: replace_attn,

--- a/ldm/deepspeed_replace.py
+++ b/ldm/deepspeed_replace.py
@@ -17,6 +17,9 @@ import math
 from torch import nn, einsum
 from einops import rearrange
 
+# TODO: Remove once resolved: https://github.com/microsoft/DeepSpeed/issues/2715
+torch.nn.Paramaeter = torch.nn.Parameter
+
 if package_available("deepspeed"):
     import deepspeed.ops.transformer as transformer_inference
     from deepspeed.ops.transformer.inference.diffusers_attention import DeepSpeedDiffusersAttention

--- a/ldm/deepspeed_replace.py
+++ b/ldm/deepspeed_replace.py
@@ -416,6 +416,8 @@ def deepspeed_injection(
         return
 
     def replace_attn(child, policy):
+        nonlocal add_warning
+
         policy_attn = policy.attention(child, use_triton_attention=use_triton_attention)
         if policy_attn is None:
             return child
@@ -426,7 +428,6 @@ def deepspeed_injection(
             qw, kw, vw, attn_ow, attn_ob, hidden_size, heads = policy_attn
 
         if use_triton_attention:
-            nonlocal add_warning
             if not add_warning:
                 logger.warn("Using DeepSpeed Triton Flash Attention. Skipped if a context is provided or with dim head higher than 128.")
                 add_warning = True
@@ -439,7 +440,6 @@ def deepspeed_injection(
             )
             attn_module = DeepSpeedDiffusersAttention(config)
         else:
-            nonlocal add_warning
             if not add_warning:
                 logger.warn("Using Flash Attention. Skipped if a context is provided or with dim head higher than 128.")
                 add_warning = True

--- a/ldm/deepspeed_replace.py
+++ b/ldm/deepspeed_replace.py
@@ -16,7 +16,7 @@ from ldm.detect_target import _detect_cuda
 import logging
 import math
 from torch import nn, einsum
-from einops import rearrange, repeat
+from einops import rearrange
 
 if package_available("deepspeed"):
     import deepspeed.ops.transformer as transformer_inference
@@ -33,7 +33,6 @@ else:
         pass
 
 logger = logging.getLogger(__name__)
-inference_cuda_module = None
 
 class InferenceEngine(InferenceEngine):
 
@@ -332,14 +331,6 @@ class FlashAttention(nn.Module):
                                                 device=device),
                                     requires_grad=False)
         self.do_out_bias = True
-
-        global inference_cuda_module
-        if inference_cuda_module is None:
-            from deepspeed.ops import op_builder
-            builder = op_builder.InferenceBuilder()
-            inference_cuda_module = builder.load()
-
-        self.linear_func = inference_cuda_module.linear_layer_fp16
 
         self.norm_factor = math.sqrt(math.sqrt(hidden_size // heads))
 

--- a/ldm/deepspeed_replace.py
+++ b/ldm/deepspeed_replace.py
@@ -7,7 +7,6 @@ from functools import partial
 from dataclasses import dataclass
 import time
 from lightning_utilities.core.imports import package_available
-from torch import nn
 from ldm.modules.attention import CrossAttention, BasicTransformerBlock
 from ldm.models.diffusion.ddpm import DiffusionWrapper
 from ldm.models.autoencoder import AutoencoderKL

--- a/ldm/deepspeed_replace.py
+++ b/ldm/deepspeed_replace.py
@@ -287,6 +287,12 @@ def _module_match(module):
 
 class FlashAttention(nn.Module):
 
+    """
+    Use https://github.com/HazyResearch/flash-attention Flash Attention Kernels.
+    
+    Note: The Flash Attention kernels are activate only when the head dimension is lower than 128 and no context tensor is provided. 
+    """
+
     def __init__(self, hidden_size: int, hidden_size_out: int, heads: int, fp16: bool = True, device: str = "cuda", max_out_tokens: int = 4096):
         super().__init__()
 

--- a/ldm/detect_target.py
+++ b/ldm/detect_target.py
@@ -1,4 +1,3 @@
-import os
 from subprocess import PIPE, Popen
 
 # Credits to AITemplate Team

--- a/ldm/lightning.py
+++ b/ldm/lightning.py
@@ -57,6 +57,7 @@ class LightningStableDiffusion(L.LightningModule):
         steps: Optional[int] = None,
         use_deepspeed: bool = False,
         enable_cuda_graph: bool = False,
+        use_triton_attention: bool = True,
         use_inference_context: bool = False,
     ):
         super().__init__()
@@ -73,8 +74,13 @@ class LightningStableDiffusion(L.LightningModule):
         self.model = instantiate_from_config(config.model)
         self.model.load_state_dict(state_dict, strict=False)
 
-        if use_deepspeed or enable_cuda_graph:
-            deepspeed_injection(self.model, fp16=fp16, enable_cuda_graph=enable_cuda_graph)
+        if use_deepspeed or enable_cuda_graph or use_triton_attention:
+            deepspeed_injection(
+                self.model,
+                fp16=fp16,
+                enable_cuda_graph=enable_cuda_graph,
+                use_triton_attention=use_triton_attention
+            )
 
         # Replace with 
         self.sampler = _SAMPLERS[sampler](self.model)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ open-clip-torch==2.7.0
 lightning
 triton>=2.0.0.dev20221005; platform_system == "Linux"
 deepspeed>=0.7.5; platform_system == "Linux"
+flash-attn; platform_system == "Linux"

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -176,7 +176,7 @@ def main(opt):
         use_deepspeed=True, # Supported on Ampere and RTX, skipped otherwise.
         enable_cuda_graph=True, # Currently enabled only for batch size 1.
         use_inference_context=False,
-        use_triton_attention=False,#opt.use_triton_attention,
+        use_triton_attention=opt.use_triton_attention,
         steps=30,
     )
 

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -152,6 +152,11 @@ def parse_args():
         default=42,
         help="the seed (for reproducible sampling)",
     )
+    parser.add_argument(
+        "--use_triton_attention",
+        action='store_true',
+        help="whether to use triton attention",
+    )
     opt = parser.parse_args()
     return opt
 
@@ -171,12 +176,13 @@ def main(opt):
         use_deepspeed=True, # Supported on Ampere and RTX, skipped otherwise.
         enable_cuda_graph=True, # Currently enabled only for batch size 1.
         use_inference_context=False,
+        use_triton_attention=opt.use_triton_attention,
         steps=30,
     )
 
-    for batch_size in [1, 2, 4]:
+    for batch_size in [1]:
         if batch_size == 1:
-            t, max_memory, images = benchmark_fn(device, 10, 5, model.predict_step, prompts=opt.prompt, batch_idx=0)
+            t, max_memory, images = benchmark_fn(device, 1, 3, model.predict_step, prompts=opt.prompt, batch_idx=0)
         else:
             t, max_memory, images = benchmark_fn(device, 10, 5, model.predict_step, prompts=[opt.prompt] * batch_size, batch_idx=0)
         print(f"Average time {t} secs on batch size {batch_size}.")

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -176,7 +176,7 @@ def main(opt):
         use_deepspeed=True, # Supported on Ampere and RTX, skipped otherwise.
         enable_cuda_graph=True, # Currently enabled only for batch size 1.
         use_inference_context=False,
-        use_triton_attention=opt.use_triton_attention,
+        use_triton_attention=False,#opt.use_triton_attention,
         steps=30,
     )
 

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -175,7 +175,7 @@ def main(opt):
         fp16=True, # Supported on GPU and CPU only, skipped otherwise.
         use_deepspeed=True, # Supported on Ampere and RTX, skipped otherwise.
         enable_cuda_graph=True, # Currently enabled only for batch size 1.
-        use_inference_context=False,
+        use_inference_context=True,
         use_triton_attention=opt.use_triton_attention,
         steps=30,
     )

--- a/scripts/txt2img_lightning.py
+++ b/scripts/txt2img_lightning.py
@@ -180,9 +180,9 @@ def main(opt):
         steps=30,
     )
 
-    for batch_size in [1]:
+    for batch_size in [1, 2, 4]:
         if batch_size == 1:
-            t, max_memory, images = benchmark_fn(device, 1, 3, model.predict_step, prompts=opt.prompt, batch_idx=0)
+            t, max_memory, images = benchmark_fn(device, 10, 5, model.predict_step, prompts=opt.prompt, batch_idx=0)
         else:
             t, max_memory, images = benchmark_fn(device, 10, 5, model.predict_step, prompts=[opt.prompt] * batch_size, batch_idx=0)
         print(f"Average time {t} secs on batch size {batch_size}.")


### PR DESCRIPTION
This PR adds Flash Attention from https://github.com/HazyResearch/flash-attention.

LDM + Flash Attention works on T4 :fire:
However, inference time is 8.698secs for batch 1 on T4. Quite higher than I expected compared to A10.
On 3090 RTX, here are the numbers I am getting:
* DeepSpeed Triton Flash Attention: 1.545 sec
* [Original Flash Attention](https://github.com/HazyResearch/flash-attention): 1.491 sec (slightly faster)

![image](https://user-images.githubusercontent.com/12861981/213016958-5bc2fd28-0d89-4e3a-8069-48a07ea0ddaa.png)
